### PR TITLE
Added support for asset hosts

### DIFF
--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -99,7 +99,11 @@ module CarrierWave
         end
 
         def public_url
-          file.public_url.to_s
+          if uploader.asset_host
+            "#{uploader.asset_host}/#{path}"
+          else
+            file.public_url.to_s
+          end
         end
 
         private

--- a/spec/carrierwave/storage/aws_spec.rb
+++ b/spec/carrierwave/storage/aws_spec.rb
@@ -32,7 +32,7 @@ describe CarrierWave::Storage::AWS::File do
   let(:bucket)     { mock(:bucket, objects: objects) }
   let(:connection) { mock(:connection, buckets: { 'example-com' => bucket }) }
   let(:file)       { mock(:file, read: '0101010') }
-  let(:uploader)   { mock(:uploader, aws_bucket: 'example-com') }
+  let(:uploader)   { mock(:uploader, aws_bucket: 'example-com', asset_host: nil) }
   let(:path)       { 'files/1/file.txt' }
 
   subject(:aws_file) do
@@ -75,6 +75,13 @@ describe CarrierWave::Storage::AWS::File do
       file.should_receive(:url_for)
 
       aws_file.url
+    end
+
+    it 'uses the asset_host and file path if asset_host is set' do
+      uploader.stub(aws_acl: :public_read)
+      uploader.stub(asset_host: 'http://example.com')
+
+      aws_file.url.should eql 'http://example.com/files/1/file.txt'
     end
   end
 end


### PR DESCRIPTION
When using carrierwave-aws, it's currently impossible to use Cloudfront due to the way the public_url is constructed. By adding support for CarrierWave's asset_host setting, a custom asset_host can be set and the uploader will return the correct full url.
