### PR TITLE
Fix filename method to avoid including authenticated url params

### DIFF
--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -60,7 +60,7 @@ module CarrierWave
 
         def filename(options = {})
           if file_url = url(options)
-            URI.parse(url).path.gsub(/.*\//, '')
+            URI.parse(file_url).path.gsub(/.*\//, '')
           end
         end
 


### PR DESCRIPTION
my_uploader.file.filename was returning the "filename.ext?AWSAccessKeyId=..." instead of simply "filename.ext" for non-public files on S3. Changed it to use the URI library to parse the url and extract just the path, and then then simplified the old regular expression to pull the filename from that. 
