### PR TITLE
Fix filename to avoid appending authenticated url params

### DIFF
--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -60,7 +60,7 @@ module CarrierWave
 
         def filename(options = {})
           if file_url = url(options)
-            file_url.gsub(/.*\/(.*?$)/, '\1')
+            URI.parse(file_url).path.gsub(/.*\//, '')
           end
         end
 


### PR DESCRIPTION
Previously, upload.file.filename was returning "filename.ext?AWSAccessKeyId=...." instead of "filename.ext". I have changed it to use URI to parse the url and extract the path without the trailing params. The filename is pulled from that path using a simpler regular expression than than what was applied to the raw url string before.
