### PR TITLE
Fix filename to avoid appending authenticated url params

### DIFF
--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -60,7 +60,7 @@ module CarrierWave
 
         def filename(options = {})
           if file_url = url(options)
-            file_url.gsub(/.*\/(.*?$)/, '\1')
+            ::File.basename(URI.parse(file_url).path)
           end
         end
 


### PR DESCRIPTION
Previously, upload.file.filename was returning "filename.ext?AWSAccessKeyId=...." instead of "filename.ext". Now using URI to parse the url and then extract the path without the trailing params, followed by a call to ::File.basename to get the filename out of that path. The regular expression that was parsing the raw url string before has been removed.
