### PR TITLE
Allow custom options for authenticated urls

### DIFF
--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -88,14 +88,14 @@ module CarrierWave
 
         def url(options = {})
           if uploader.aws_acl != :public_read
-            authenticated_url
+            authenticated_url(options)
           else
             public_url
           end
         end
 
-        def authenticated_url
-          file.url_for(:read, expires: uploader.aws_authenticated_url_expiration).to_s
+        def authenticated_url(options = {})
+          file.url_for(:read, { expires: uploader.aws_authenticated_url_expiration }.merge(options)).to_s
         end
 
         def public_url

--- a/spec/carrierwave/storage/aws_spec.rb
+++ b/spec/carrierwave/storage/aws_spec.rb
@@ -59,6 +59,14 @@ describe CarrierWave::Storage::AWS::File do
 
       aws_file.authenticated_url
     end
+
+    it 'requests a url for reading with custom options' do
+      uploader.stub(aws_authenticated_url_expiration: 60)
+
+      file.should_receive(:url_for).with(:read, hash_including(response_content_disposition: 'attachment'))
+
+      aws_file.authenticated_url(response_content_disposition: 'attachment')
+    end
   end
 
   describe '#url' do


### PR DESCRIPTION
This allows to pass AWS SDK options for urls as described in
http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/S3/S3Object.html#url_for-instance_method

My use case is to use `model.file_url(response_content_disposition: 'attachment')`.
