### PR TITLE
Forces read options to be a hash (regression)

### DIFF
--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -103,7 +103,7 @@ module CarrierWave
         end
 
         def uploader_read_options
-          uploader.aws_read_options
+          uploader.aws_read_options || {}
         end
 
         def uploader_write_options(new_file)

--- a/spec/carrierwave/storage/aws_spec.rb
+++ b/spec/carrierwave/storage/aws_spec.rb
@@ -74,6 +74,11 @@ describe CarrierWave::Storage::AWS::File do
     it 'includes aws_read_options' do
       aws_file.uploader_read_options.should == { encryption_key: 'abc' }
     end
+
+    it 'ensures that read options are a hash' do
+      uploader.stub(:aws_read_options) { nil }
+      aws_file.uploader_read_options.should == {}
+    end
   end
 
   describe '#to_file' do


### PR DESCRIPTION
With 0.4.0 unspecified read options are send as nil to the aws-sdk, which causes a `NoMethodError: undefined method `[]=' for nil:NilClass` error in the aws-sdk.

```
Stacktrace (most recent call first):

  aws/s3/s3_object.rb:1077:in `read'
    options[:bucket_name] = bucket.name
  carrierwave/storage/aws.rb:68:in `read'
    file.read(uploader_read_options)
```

The casting was removed during this refactoring: https://github.com/sorentwo/carrierwave-aws/commit/50608f019649f9c7582c8de51f68c0b71c308cd7
