### PR TITLE
Implement AWS as a cache storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'carrierwave', git: 'git://github.com/carrierwaveuploader/carrierwave.git',
+    ref: '7a993542701b'
+
 # Specify your gem's dependencies in carrierwave-aws-sdk.gemspec
 gemspec

--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -21,6 +21,24 @@ module CarrierWave
         File.new(uploader, connection, uploader.store_path(identifier))
       end
 
+      def cache!(file)
+        File.new(uploader, connection, uploader.cache_path).tap do |aws_file|
+          aws_file.store(file)
+        end
+      end
+
+      def retrieve_from_cache!(identifier)
+        File.new(uploader, connection, uploader.cache_path(identifier))
+      end
+
+      def delete_dir!(path)
+        # do nothing, because there's no such things as 'empty directory'
+      end
+
+      def clean_cache!(seconds)
+        raise 'Missing clean_cache! implementation for cache storage AWS'
+      end
+
       def connection
         @connection ||= begin
           credentials = uploader.aws_credentials
@@ -73,9 +91,21 @@ module CarrierWave
         end
 
         def store(new_file)
-          @file = bucket.objects[path].write(uploader_write_options(new_file))
+          if new_file.is_a?(self.class)
+            new_file.move_to(path)
+          else
+            @file = bucket.objects[path].write(uploader_write_options(new_file))
+          end
 
           true
+        end
+
+        def move_to(path)
+          options = uploader_write_options(self)
+          options.delete(:file)
+
+          file.move_to(path, options)
+          self
         end
 
         def to_file


### PR DESCRIPTION
The commits https://github.com/carrierwaveuploader/carrierwave/commit/7a993542701b that's related to https://github.com/carrierwaveuploader/carrierwave/pull/1312 added the option to switch cache storages. carrierwave-aws needs that.

However the carrierwave version with the functionality wasn't published yet, so this implementation isn't ready to be merged, this PR is a WIP to get the code ready for when that's published.
