### PR TITLE
update dependency declarations

### DIFF
--- a/carrierwave-aws.gemspec
+++ b/carrierwave-aws.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'carrierwave', '>= 0.7'
-  gem.add_dependency 'aws-sdk',     '>= 1.29'
+  gem.add_dependency 'carrierwave', '~> 0.7'
+  gem.add_dependency 'aws-sdk',     '~> 1.29'
 
   gem.add_development_dependency 'rspec', '~> 2.14'
 end


### PR DESCRIPTION
AWS is releasing v2 of their SDK which will not be backwards compatible with v1 so this changes the dependency declarations to use the twiddle-wakka syntax ensuring that the correct version is used. I went ahead and did the same for the carrierwave dependency but I'm not sure it is necessary because it doesn't appear to follow semantic versioning.
