### PR TITLE
Allow instantiation of S3 without credentials

### DIFF
--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -24,7 +24,10 @@ module CarrierWave
       def connection
         @connection ||= begin
           credentials = uploader.aws_credentials
-          self.class.connection_cache[credentials] ||= ::AWS::S3.new(credentials)
+          # We don't always need credentials, for instance, when using IAM roles
+          # Passing a 'nil' credentials argument will break AWS::S3.new()
+          args = [credentials] ? args : []
+          self.class.connection_cache[credentials] ||= ::AWS::S3.new(*args)
         end
       end
 


### PR DESCRIPTION
Hi! We use IAM Roles, and we needed this patch to get it working. Hope you find it useful!
