### PR TITLE
Fix File#exists? to actually check for existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix `exists?` method of AWS::File (previously it always returned true)
+  [Felix Bünemann]
 * Fix `filename` method of AWS::File for private files and remove url encoding.
   [Felix Bünemann]
 

--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -58,7 +58,7 @@ module CarrierWave
         end
 
         def exists?
-          !!file
+          file.exists?
         end
 
         def filename(options = {})

--- a/spec/carrierwave/storage/aws_spec.rb
+++ b/spec/carrierwave/storage/aws_spec.rb
@@ -53,6 +53,14 @@ describe CarrierWave::Storage::AWS::File do
     CarrierWave::Storage::AWS::File.new(uploader, connection, path)
   end
 
+  describe '#exists?' do
+    it 'checks if the remote file object exists' do
+      expect(file).to receive(:exists?).and_return(true)
+
+      aws_file.exists?
+    end
+  end
+
   describe '#read' do
     it 'reads from the remote file object' do
       expect(aws_file.read).to eq('0101010')


### PR DESCRIPTION
The current code is a no-op, because you can read back any key from the bucket object, so it will always return true.
