### PR TITLE
Fix filename for private files and special chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Fix `filename` method of AWS::File for private files and remove url encoding.
+  [Felix Bünemann]
+
 ## Version 0.4.1 2014-03-28
 
 * Fix regression in `aws_read_options` defaulting to `nil` rather than an empty

--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -63,7 +63,7 @@ module CarrierWave
 
         def filename(options = {})
           if file_url = url(options)
-            file_url.gsub(/.*\/(.*?$)/, '\1')
+            URI.decode(file_url.split('?').first).gsub(/.*\/(.*?$)/, '\1')
           end
         end
 

--- a/spec/carrierwave/storage/aws_spec.rb
+++ b/spec/carrierwave/storage/aws_spec.rb
@@ -147,4 +147,12 @@ describe CarrierWave::Storage::AWS::File do
       expect(aws_file.url).to eq('http://example.com/files/1/file.txt')
     end
   end
+
+  describe '#filename' do
+    it 'returns the filename from the url' do
+      expect(aws_file).to receive(:url).and_return('http://example.com/files/1/file%201.txt?foo=bar/baz.txt')
+
+      expect(aws_file.filename).to eq('file 1.txt')
+    end
+  end
 end


### PR DESCRIPTION
This fixes two problems:
- The signed url for private files can contain slashes, which broke the
  previous code
- The filename can contain url encoded characters if a non-default
  sanitization regex is used

Fix taken from fog file class in carrierwave master.
