### PR TITLE
Add ability to sign cloudfront urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ If you have a custom uploader that specifies additional headers for each URL, pl
 If you migrate from `fog` you probably have something like `url(query: {'my-header': 'my-value'})`.
 With `carrierwave-aws` the `query` part becomes obsolete, just use a hash of headers.
 
+### Signing Cloudfront URLs
+
+To sign cloudfront urls, install and configure the `cloudfront-signer` gem, then configure as follows:
+
+```ruby
+CarrierWave.configure do |config|
+  config.storage    = :aws
+  config.aws_bucket = ENV.fetch('S3_BUCKET_NAME')
+  config.aws_acl    = false
+  config.asset_host = 'https://sdfsdkjksdjflkj.cloudfront.net'
+  config.sign_cloudfront = true
+  config.aws_credentials = {
+    access_key_id:     ENV.fetch('AWS_ACCESS_KEY_ID'),
+    secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY')
+  }
+end
+```
+
 ## Contributing
 
 In order to run the integration specs you will need to configure some

--- a/lib/carrierwave-aws.rb
+++ b/lib/carrierwave-aws.rb
@@ -11,6 +11,7 @@ class CarrierWave::Uploader::Base
   add_config :aws_acl
   add_config :aws_read_options
   add_config :aws_write_options
+  add_config :sign_cloudfront
 
   configure do |config|
     config.storage_engines[:aws] = 'CarrierWave::Storage::AWS'

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -59,7 +59,7 @@ module CarrierWave
           unless defined?(::AWS::CF::Signer)
             raise "You must include the cloudfront-signer gem and configure it properly to use signed cloudfront urls"
           end
-          ::AWS::CF::Signer.sign_url(public_url)
+          ::AWS::CF::Signer.sign_url([public_url, options.to_query].join '?')
         elsif uploader.aws_acl != :public_read
           authenticated_url(options)
         else

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -55,7 +55,12 @@ module CarrierWave
       end
 
       def url(options = {})
-        if uploader.aws_acl != :public_read
+        if uploader.sign_cloudfront
+          unless defined?(::AWS::CF::Signer)
+            raise "You must include the cloudfront-signer gem and configure it properly to use signed cloudfront urls"
+          end
+          ::AWS::CF::Signer.sign_url(public_url)
+        elsif uploader.aws_acl != :public_read
           authenticated_url(options)
         else
           public_url


### PR DESCRIPTION
This allows signed cloudfront urls using the `cloudfront-signer` gem