### PR TITLE
Update aws-sdk to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.6.0
+
+* Breaking Change: Updated to use AWS-SDK v2 [Mark Oleson]
+  * You must specify a region in your `aws_credentials` configuration
+  * You must use hyphens in ACLs instead of underscores (`:public_read` becomes `:'public-read'` or `'public-read'`)
+
 ## Version 0.5.0 2015-01-31
 
 * Change: Nudge the expected AWS-SDK version.

--- a/README.md
+++ b/README.md
@@ -38,32 +38,17 @@ the use of `aws_bucket` instead of `fog_directory`, and `aws_acl` instead of
 CarrierWave.configure do |config|
   config.storage    = :aws
   config.aws_bucket = ENV.fetch('S3_BUCKET_NAME')
-  config.aws_acl    = :public_read
+  config.aws_acl    = :'public-read'
   config.asset_host = 'http://example.com'
   config.aws_authenticated_url_expiration = 60 * 60 * 24 * 365
 
   config.aws_credentials = {
     access_key_id:     ENV.fetch('AWS_ACCESS_KEY_ID'),
-    secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY')
+    secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+    region:            ENV.fetch('AWS_REGION') # Required
   }
 end
 ```
-
-If you want to supply your own AWS configuration, put it inside
-`config.aws_credentials` like this:
-
-```ruby
-config.aws_credentials = {
-  access_key_id:     ENV['AWS_ACCESS_KEY_ID'],
-  secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-  config: AWS.config(my_aws_options)
-}
-```
-
-`AWS.config` will return `AWS::Core::Configuration` object which is used through
-`aws-sdk` gem. Browse [Amazon Docs][amazon-docs] for additional info. For
-example, if you want to turn off SSL for your asset URLs, you could simply set
-`AWS.config(use_ssl: false)`.
 
 ### Custom options for AWS URLs
 
@@ -102,5 +87,3 @@ cp .env.sample .env
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
-
-[amazon-docs]: http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/Core/Configuration.html

--- a/carrierwave-aws.gemspec
+++ b/carrierwave-aws.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'carrierwave', '~> 0.7'
-  gem.add_dependency 'aws-sdk',     '~> 1.58'
+  gem.add_dependency 'aws-sdk',     '~> 2.0.47'
 
   gem.add_development_dependency 'rspec', '~> 3'
 end

--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -1,4 +1,4 @@
-require 'aws/s3'
+require 'aws-sdk-core'
 
 module CarrierWave
   module Storage
@@ -23,7 +23,7 @@ module CarrierWave
 
       def connection
         @connection ||= begin
-          self.class.connection_cache[credentials] ||= ::AWS::S3.new(*credentials)
+          self.class.connection_cache[credentials] ||= ::Aws::S3::Client.new(*credentials)
         end
       end
 

--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-core'
+require 'aws-sdk-resources'
 
 module CarrierWave
   module Storage
@@ -23,7 +23,7 @@ module CarrierWave
 
       def connection
         @connection ||= begin
-          self.class.connection_cache[credentials] ||= ::Aws::S3::Client.new(*credentials)
+          self.class.connection_cache[credentials] ||= ::Aws::S3::Resource.new(*credentials)
         end
       end
 

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -19,7 +19,7 @@ module CarrierWave
       end
 
       def delete
-        file.delete
+        connection.delete_object(bucket: uploader.aws_bucket, key: path)
       end
 
       def extension
@@ -45,7 +45,7 @@ module CarrierWave
       end
 
       def store(new_file)
-        @file = bucket.objects[path].write(uploader_write_options(new_file))
+        @file = connection.put_object(uploader_write_options(new_file))
 
         true
       end
@@ -87,8 +87,10 @@ module CarrierWave
         aws_write_options = uploader.aws_write_options || {}
 
         { acl:          uploader.aws_acl,
+          body:         new_file.to_file,
+          bucket:       uploader.aws_bucket,
           content_type: new_file.content_type,
-          file:         new_file.path
+          key:          path
         }.merge(aws_attributes).merge(aws_write_options)
       end
 
@@ -104,12 +106,8 @@ module CarrierWave
 
       private
 
-      def bucket
-        @bucket ||= connection.buckets[uploader.aws_bucket]
-      end
-
       def file
-        @file ||= bucket.objects[path]
+        @file ||= connection.get_object(bucket: uploader.aws_bucket, key: path)
       end
     end
   end

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -11,7 +11,7 @@ module CarrierWave
       end
 
       def attributes
-        file.head.data
+        file.data.to_h
       end
 
       def content_type

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -75,7 +75,7 @@ module CarrierWave
       end
 
       def copy_to(new_path)
-        file.copy_to(bucket.objects[new_path], uploader_copy_options)
+        bucket.object(new_path).copy_from(copy_source: "#{bucket.name}/#{file.key}")
       end
 
       def uploader_read_options

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -63,7 +63,7 @@ module CarrierWave
       end
 
       def authenticated_url(options = {})
-        file.url_for(:read, { expires: uploader.aws_authenticated_url_expiration }.merge(options)).to_s
+        file.presigned_url(:get, { expires_in: uploader.aws_authenticated_url_expiration }.merge(options))
       end
 
       def public_url

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -55,7 +55,7 @@ module CarrierWave
       end
 
       def url(options = {})
-        if uploader.aws_acl != :public_read
+        if uploader.aws_acl.to_s != 'public-read'
           authenticated_url(options)
         else
           public_url

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -19,7 +19,7 @@ module CarrierWave
       end
 
       def delete
-        connection.delete_object(bucket: uploader.aws_bucket, key: path)
+        file.delete
       end
 
       def extension
@@ -45,7 +45,7 @@ module CarrierWave
       end
 
       def store(new_file)
-        @file = connection.put_object(uploader_write_options(new_file))
+        @file = file.put(uploader_write_options(new_file))
 
         true
       end
@@ -88,9 +88,7 @@ module CarrierWave
 
         { acl:          uploader.aws_acl,
           body:         new_file.to_file,
-          bucket:       uploader.aws_bucket,
           content_type: new_file.content_type,
-          key:          path
         }.merge(aws_attributes).merge(aws_write_options)
       end
 
@@ -106,8 +104,12 @@ module CarrierWave
 
       private
 
+      def bucket
+        @bucket ||= connection.bucket(uploader.aws_bucket)
+      end
+
       def file
-        @file ||= connection.get_object(bucket: uploader.aws_bucket, key: path)
+        @file ||= bucket.object(path)
       end
     end
   end

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -87,7 +87,7 @@ describe CarrierWave::Storage::AWSFile do
     it 'requests a url for reading with the configured expiration' do
       allow(uploader).to receive(:aws_authenticated_url_expiration) { 60 }
 
-      expect(file).to receive(:url_for).with(:read, expires: 60)
+      expect(file).to receive(:presigned_url).with(:get, { expires_in: 60 })
 
       aws_file.authenticated_url
     end
@@ -95,7 +95,7 @@ describe CarrierWave::Storage::AWSFile do
     it 'requests a url for reading with custom options' do
       allow(uploader).to receive(:aws_authenticated_url_expiration) { 60 }
 
-      expect(file).to receive(:url_for).with(:read, hash_including(response_content_disposition: 'attachment'))
+      expect(file).to receive(:presigned_url).with(:get, hash_including(response_content_disposition: 'attachment'))
 
       aws_file.authenticated_url(response_content_disposition: 'attachment')
     end

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -9,7 +9,7 @@ describe CarrierWave::Storage::AWSFile do
   let(:uploader) do
     double(:uploader,
       aws_bucket: 'example-com',
-      aws_acl: 'public-read',
+      aws_acl: :'public-read',
       aws_attributes: {},
       asset_host: nil,
       aws_read_options: { encryption_key: 'abc' },
@@ -41,7 +41,7 @@ describe CarrierWave::Storage::AWSFile do
       uploader_write_options = aws_file.uploader_write_options(stub_file)
 
       expect(uploader_write_options).to include(
-        acl:            'public-read',
+        acl:            :'public-read',
         content_type:   'image/png',
         encryption_key: 'def'
       )
@@ -103,7 +103,7 @@ describe CarrierWave::Storage::AWSFile do
 
   describe '#url' do
     it 'requests a public url if acl is public readable' do
-      allow(uploader).to receive(:aws_acl) { :public_read }
+      allow(uploader).to receive(:aws_acl) { :'public-read' }
 
       expect(file).to receive(:public_url)
 
@@ -114,13 +114,13 @@ describe CarrierWave::Storage::AWSFile do
       allow(uploader).to receive(:aws_acl) { :private }
       allow(uploader).to receive(:aws_authenticated_url_expiration) { 60 }
 
-      expect(file).to receive(:url_for)
+      expect(file).to receive(:presigned_url).with(:get, { expires_in: 60 })
 
       aws_file.url
     end
 
     it 'uses the asset_host and file path if asset_host is set' do
-      allow(uploader).to receive(:aws_acl) { :public_read }
+      allow(uploader).to receive(:aws_acl) { :'public-read' }
       allow(uploader).to receive(:asset_host) { 'http://example.com' }
 
       expect(aws_file.url).to eq('http://example.com/files/1/file.txt')

--- a/spec/carrierwave/storage/aws_spec.rb
+++ b/spec/carrierwave/storage/aws_spec.rb
@@ -19,13 +19,6 @@ describe CarrierWave::Storage::AWS do
       storage.connection
     end
 
-    it 'instantiates a new connection without any credentials' do
-      pending("aws-sdk v2 requires a region to be specified at instantiation time")
-      allow(uploader).to receive(:aws_credentials) { nil }
-
-      expect { storage.connection }.not_to raise_exception
-    end
-
     it 'caches connections by credentials' do
       expect(storage.connection).to eq(storage.connection)
     end

--- a/spec/carrierwave/storage/aws_spec.rb
+++ b/spec/carrierwave/storage/aws_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe CarrierWave::Storage::AWS do
-  let(:credentials) { { access_key_id: 'abc', secret_access_key: '123' } }
+  let(:credentials) { { access_key_id: 'abc', secret_access_key: '123', region: 'us-east-1' } }
   let(:uploader)    { double(:uploader, aws_credentials: credentials) }
 
   subject(:storage) do
@@ -14,12 +14,13 @@ describe CarrierWave::Storage::AWS do
 
   describe '#connection' do
     it 'instantiates a new connection with credentials' do
-      expect(AWS::S3).to receive(:new).with(credentials)
+      expect(Aws::S3::Resource).to receive(:new).with(credentials)
 
       storage.connection
     end
 
     it 'instantiates a new connection without any credentials' do
+      pending("aws-sdk v2 requires a region to be specified at instantiation time")
       allow(uploader).to receive(:aws_credentials) { nil }
 
       expect { storage.connection }.not_to raise_exception

--- a/spec/features/querying_files_spec.rb
+++ b/spec/features/querying_files_spec.rb
@@ -13,8 +13,7 @@ describe 'Querying Files', type: :feature do
     instance.retrieve_from_store!('image.png')
 
     expect(instance.file.attributes).to include(
-      :meta,
-      :restore_in_progress,
+      :metadata,
       :content_type,
       :etag,
       :accept_ranges,

--- a/spec/features/querying_files_spec.rb
+++ b/spec/features/querying_files_spec.rb
@@ -44,4 +44,21 @@ describe 'Querying Files', type: :feature do
 
     image.close
   end
+
+  it 'gets a url for remote files' do
+    uploader = Class.new(CarrierWave::Uploader::Base) do
+      def filename; 'image.png'; end
+    end
+
+    image    = File.open('spec/fixtures/image.png', 'r')
+    instance = uploader.new
+
+    instance.store!(image)
+    instance.retrieve_from_store!('image.png')
+
+    expect(instance.url).to eq("https://#{ENV['S3_BUCKET_NAME']}.s3.amazonaws.com/#{instance.path}")
+
+    image.close
+    instance.file.delete
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ RSpec.configure do |config|
     CarrierWave.configure do |config|
       config.storage    = :aws
       config.aws_bucket = ENV['S3_BUCKET_NAME']
-      config.aws_acl    = :public_read
+      config.aws_acl    = 'public-read'
 
       config.aws_credentials = {
         access_key_id:     ENV['S3_ACCESS_KEY'],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ RSpec.configure do |config|
     CarrierWave.configure do |config|
       config.storage    = :aws
       config.aws_bucket = ENV['S3_BUCKET_NAME']
-      config.aws_acl    = 'public-read'
+      config.aws_acl    = :'public-read'
 
       config.aws_credentials = {
         access_key_id:     ENV['S3_ACCESS_KEY'],


### PR DESCRIPTION
Heya, this is a first attempt at upgrading the gem to use v2 of the aws-sdk gem.

The entire test suite passes, minus one test I've marked as pending. The new version of aws-sdk requires a region to be specified at instantiation of resources and clients, but we currently have a test specifically checking that you can instantiate the connection without **any** credentials. I'd recommend we just delete the test.

Here are some notes:
* `:public_read` is no longer a valid ACL, I've replaced instances in tests with what is valid: `'public-read'`
* I had to introduce a `CarrierWave::SanitizedFile` instance in the `AWSFile` spec since the implementation now relies on the `to_file` defined in it. If needed/wanted, I can keep fiddling with the test doubles and perhaps get this to work without it.
* I'm not sure what is the earliest version of v2 we should support, so I've specified the latest. Once we settle on the implementation, maybe we can just keep rolling back the version until we find a version that doesn't work with what we've written and call the version directly after that the earliest supported?
* I'm not certain how the numbers in the readme for Disk Space, Lines of Code, Boot Time, Runtime Deps, and Develop Deps were generated, so I've left them alone.