### PR TITLE
Support signed urls as required for serving private content through Cloudfront 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ CarrierWave.configure do |config|
 
   # Optional: Signing of download urls, e.g. for serving private
   # content through CloudFront.
-  config.aws_sign_urls = {
-    signer: -> { |unsigned_url, options| Aws::CF::Signer.sign_url unsigned_url, options }
-  }
+  config.aws_signer = -> { |unsigned_url, options| Aws::CF::Signer.sign_url unsigned_url, options }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ CarrierWave.configure do |config|
 
   # Optional: Signing of download urls, e.g. for serving private
   # content through CloudFront.
-  config.sign_urls = {
-    signer: lamda { |unsigned_url, options| Aws::CF::Signer.sign_url unsigned_url, options }
+  config.aws_sign_urls = {
+    signer: -> { |unsigned_url, options| Aws::CF::Signer.sign_url unsigned_url, options }
   }
 end
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ CarrierWave.configure do |config|
     secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
     region:            ENV.fetch('AWS_REGION') # Required
   }
+
+  # Optional: Signing of download urls, e.g. for serving private
+  # content through CloudFront.
+  config.sign_urls = {
+    signer: lamda { |unsigned_url, options| Aws::CF::Signer.sign_url unsigned_url, options }
+  }
 end
 ```
 

--- a/lib/carrierwave-aws.rb
+++ b/lib/carrierwave-aws.rb
@@ -23,7 +23,7 @@ class CarrierWave::Uploader::Base
   add_config :aws_bucket
   add_config :aws_read_options
   add_config :aws_write_options
-  add_config :sign_urls
+  add_config :aws_sign_urls
 
   configure do |config|
     config.storage_engines[:aws] = 'CarrierWave::Storage::AWS'

--- a/lib/carrierwave-aws.rb
+++ b/lib/carrierwave-aws.rb
@@ -23,7 +23,6 @@ class CarrierWave::Uploader::Base
   add_config :aws_bucket
   add_config :aws_read_options
   add_config :aws_write_options
-  add_config :aws_sign_urls
 
   configure do |config|
     config.storage_engines[:aws] = 'CarrierWave::Storage::AWS'
@@ -47,11 +46,35 @@ class CarrierWave::Uploader::Base
     normalized
   end
 
+  def self.aws_signer
+    @aws_signer
+  end
+
+  def self.aws_signer=(signer)
+    @aws_signer = validated_signer(signer)
+  end
+
+  def self.validated_signer(signer)
+    unless signer.instance_of?(Proc) && signer.arity == 2
+      raise ConfigurationError.new("Invalid signer option. Signer proc has to respond to '.call(unsigned_url, options)'")
+    end
+
+    signer
+  end
+
   def aws_acl
     @aws_acl || self.class.aws_acl
   end
 
   def aws_acl=(acl)
     @aws_acl = self.class.normalized_acl(acl)
+  end
+
+  def aws_signer
+    @aws_signer || self.class.aws_signer
+  end
+
+  def aws_signer=(signer)
+    @aws_signer = self.class.validated_signer(signer)
   end
 end

--- a/lib/carrierwave-aws.rb
+++ b/lib/carrierwave-aws.rb
@@ -13,6 +13,7 @@ class CarrierWave::Uploader::Base
   add_config :aws_acl
   add_config :aws_read_options
   add_config :aws_write_options
+  add_config :sign_urls
 
   configure do |config|
     config.storage_engines[:aws] = 'CarrierWave::Storage::AWS'

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -61,7 +61,7 @@ module CarrierWave
       end
 
       def signed_url(options = {})
-        uploader.sign_urls[:signer].call(public_url, options)
+        uploader.aws_sign_urls[:signer].call(public_url, options)
       end
 
       def authenticated_url(options = {})
@@ -77,7 +77,7 @@ module CarrierWave
       end
 
       def url(options = {})
-        if uploader.sign_urls
+        if uploader.aws_sign_urls
           signed_url(options)
         elsif uploader.aws_acl.to_s != 'public-read'
           authenticated_url(options)

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -93,7 +93,7 @@ module CarrierWave
       end
 
       def signer
-        uploader.aws_sign_urls.try(:fetch, :signer)
+        uploader.aws_signer
       end
     end
   end

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -61,7 +61,7 @@ module CarrierWave
       end
 
       def signed_url(options = {})
-        uploader.aws_sign_urls[:signer].call(public_url, options)
+        uploader.signer.call(public_url, options)
       end
 
       def authenticated_url(options = {})
@@ -77,7 +77,7 @@ module CarrierWave
       end
 
       def url(options = {})
-        if uploader.aws_sign_urls
+        if uploader.signer
           signed_url(options)
         elsif uploader.aws_acl.to_s != 'public-read'
           authenticated_url(options)
@@ -90,6 +90,10 @@ module CarrierWave
 
       def bucket
         @bucket ||= connection.bucket(uploader.aws_bucket)
+      end
+
+      def signer
+        uploader.aws_sign_urls.fetch(:signer)
       end
     end
   end

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -61,7 +61,7 @@ module CarrierWave
       end
 
       def signed_url(options = {})
-        uploader.signer.call(public_url, options)
+        signer.call(public_url, options)
       end
 
       def authenticated_url(options = {})
@@ -77,7 +77,7 @@ module CarrierWave
       end
 
       def url(options = {})
-        if uploader.signer
+        if signer
           signed_url(options)
         elsif uploader.aws_acl.to_s != 'public-read'
           authenticated_url(options)

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -60,6 +60,10 @@ module CarrierWave
         bucket.object(new_path).copy_from(copy_source: "#{bucket.name}/#{file.key}")
       end
 
+      def signed_url(options = {})
+        uploader.sign_urls[:signer].call(public_url, options)
+      end
+
       def authenticated_url(options = {})
         file.presigned_url(:get, aws_options.expiration_options(options))
       end
@@ -73,7 +77,9 @@ module CarrierWave
       end
 
       def url(options = {})
-        if uploader.aws_acl.to_s != 'public-read'
+        if uploader.sign_urls
+          signed_url(options)
+        elsif uploader.aws_acl.to_s != 'public-read'
           authenticated_url(options)
         else
           public_url

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -93,7 +93,7 @@ module CarrierWave
       end
 
       def signer
-        uploader.aws_sign_urls.fetch(:signer)
+        uploader.aws_sign_urls.try(:fetch, :signer)
       end
     end
   end

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -25,7 +25,7 @@ describe CarrierWave::Uploader::Base do
     it 'does not allow unknown control values' do
       expect {
         uploader.aws_acl = 'everybody'
-      }.to raise_exception
+      }.to raise_exception CarrierWave::Uploader::Base::ConfigurationError
     end
 
     it 'normalizes the set value' do
@@ -57,7 +57,7 @@ describe CarrierWave::Uploader::Base do
     it 'does not allow signer with unknown api' do
       signer_proc = -> (unsigned_url) { }
 
-      expect { uploader.aws_signer = signer_proc }.to raise_exception
+      expect { uploader.aws_signer = signer_proc }.to raise_exception CarrierWave::Uploader::Base::ConfigurationError
     end
   end
 end

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -46,4 +46,18 @@ describe CarrierWave::Uploader::Base do
       expect(instance.aws_acl).to eq('public-read')
     end
   end
+
+  describe '#aws_signer' do
+    it 'allows proper signer object' do
+      signer_proc = -> (unsigned_url, options) { }
+
+      expect { uploader.aws_signer = signer_proc }.not_to raise_exception
+    end
+
+    it 'does not allow signer with unknown api' do
+      signer_proc = -> (unsigned_url) { }
+
+      expect { uploader.aws_signer = signer_proc }.to raise_exception
+    end
+  end
 end

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -31,7 +31,7 @@ describe CarrierWave::Uploader::Base do
     it 'does not allow unknown control values' do
       expect {
         uploader.aws_acl = 'everybody'
-      }.to raise_exception CarrierWave::Uploader::Base::ConfigurationError
+      }.to raise_exception(CarrierWave::Uploader::Base::ConfigurationError)
     end
 
     it 'normalizes the set value' do

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -12,7 +12,7 @@ describe CarrierWave::Storage::AWSFile do
       aws_acl: :'public-read',
       aws_attributes: {},
       asset_host: nil,
-      sign_urls: nil,
+      aws_sign_urls: nil,
       aws_read_options: { encryption_key: 'abc' },
       aws_write_options: { encryption_key: 'def' }
     )
@@ -67,7 +67,7 @@ describe CarrierWave::Storage::AWSFile do
       signature = 'Signature=QWERTZ&Key-Pair-Id=XYZ'
       cloudfront_signer = -> (unsigned_url, options) { [unsigned_url, signature].join('?') }
 
-      allow(uploader).to receive(:sign_urls) { {signer: cloudfront_signer} }
+      allow(uploader).to receive(:aws_sign_urls) { {signer: cloudfront_signer} }
       expect(file).to receive(:public_url) { 'http://example.com' }
 
       expect(aws_file.url).to eq "http://example.com?#{signature}"

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -63,10 +63,10 @@ describe CarrierWave::Storage::AWSFile do
       aws_file.url
     end
 
-    let(:cloudfront_signer) { -> (unsigned_url, options) { [unsigned_url, signature].join('?') } }
-    let(:signature) { 'Signature=QWERTZ&Key-Pair-Id=XYZ' }
-
     it 'requests an signed url if url signing is configured' do
+      signature = 'Signature=QWERTZ&Key-Pair-Id=XYZ'
+      cloudfront_signer = -> (unsigned_url, options) { [unsigned_url, signature].join('?') }
+
       allow(uploader).to receive(:sign_urls) { {signer: cloudfront_signer} }
       expect(file).to receive(:public_url) { 'http://example.com' }
 

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -12,7 +12,7 @@ describe CarrierWave::Storage::AWSFile do
       aws_acl: :'public-read',
       aws_attributes: {},
       asset_host: nil,
-      aws_sign_urls: nil,
+      signer: nil,
       aws_read_options: { encryption_key: 'abc' },
       aws_write_options: { encryption_key: 'def' }
     )
@@ -67,7 +67,7 @@ describe CarrierWave::Storage::AWSFile do
       signature = 'Signature=QWERTZ&Key-Pair-Id=XYZ'
       cloudfront_signer = -> (unsigned_url, options) { [unsigned_url, signature].join('?') }
 
-      allow(uploader).to receive(:aws_sign_urls) { {signer: cloudfront_signer} }
+      allow(uploader).to receive(:signer) { cloudfront_signer }
       expect(file).to receive(:public_url) { 'http://example.com' }
 
       expect(aws_file.url).to eq "http://example.com?#{signature}"

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -12,7 +12,7 @@ describe CarrierWave::Storage::AWSFile do
       aws_acl: :'public-read',
       aws_attributes: {},
       asset_host: nil,
-      signer: nil,
+      aws_sign_urls: nil,
       aws_read_options: { encryption_key: 'abc' },
       aws_write_options: { encryption_key: 'def' }
     )
@@ -67,7 +67,7 @@ describe CarrierWave::Storage::AWSFile do
       signature = 'Signature=QWERTZ&Key-Pair-Id=XYZ'
       cloudfront_signer = -> (unsigned_url, options) { [unsigned_url, signature].join('?') }
 
-      allow(uploader).to receive(:signer) { cloudfront_signer }
+      allow(uploader).to receive(:aws_sign_urls) { { signer: cloudfront_signer} }
       expect(file).to receive(:public_url) { 'http://example.com' }
 
       expect(aws_file.url).to eq "http://example.com?#{signature}"

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -12,7 +12,7 @@ describe CarrierWave::Storage::AWSFile do
       aws_acl: :'public-read',
       aws_attributes: {},
       asset_host: nil,
-      aws_sign_urls: nil,
+      aws_signer: nil,
       aws_read_options: { encryption_key: 'abc' },
       aws_write_options: { encryption_key: 'def' }
     )
@@ -67,7 +67,7 @@ describe CarrierWave::Storage::AWSFile do
       signature = 'Signature=QWERTZ&Key-Pair-Id=XYZ'
       cloudfront_signer = -> (unsigned_url, options) { [unsigned_url, signature].join('?') }
 
-      allow(uploader).to receive(:aws_sign_urls) { { signer: cloudfront_signer} }
+      allow(uploader).to receive(:aws_signer) { cloudfront_signer }
       expect(file).to receive(:public_url) { 'http://example.com' }
 
       expect(aws_file.url).to eq "http://example.com?#{signature}"


### PR DESCRIPTION
Hi,

first of all, thank you very much for your great gem!

I'm working on a small project storing private content like photos in amazon s3 and serving it using authenticated urls. Currently the performance isn't that good at all. Therefor, I added Cloudfront to my project and added some minor changes to carrierwave-aws in order to use the signed urls feature that Cloudfront provides.

In order to not add gem dependancies to carrierwave-aws and for flexibility on the signing part I choose to inject a 'signer' proc into the url generation chain. This way, any kind of urls (except the authenticated urls) can be signed. In the example I use the [cloudfront-signer](https://github.com/58bits/cloudfront-signer) gem.

Please let me know your opinion and feedback.