### PR TITLE
aws_acl should follow the inheritance chain

### DIFF
--- a/lib/carrierwave-aws.rb
+++ b/lib/carrierwave-aws.rb
@@ -23,13 +23,10 @@ class CarrierWave::Uploader::Base
   add_config :aws_bucket
   add_config :aws_read_options
   add_config :aws_write_options
+  add_config :aws_acl
 
   configure do |config|
     config.storage_engines[:aws] = 'CarrierWave::Storage::AWS'
-  end
-
-  def self.aws_acl
-    @aws_acl
   end
 
   def self.aws_acl=(acl)
@@ -44,10 +41,6 @@ class CarrierWave::Uploader::Base
     end
 
     normalized
-  end
-
-  def aws_acl
-    @aws_acl || self.class.aws_acl
   end
 
   def aws_acl=(acl)

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -20,7 +20,8 @@ describe CarrierWave::Uploader::Base do
   end
 
   describe '#aws_acl' do
-    it 'allows known acess control values' do expect {
+    it 'allows known acess control values' do
+      expect {
         uploader.aws_acl = 'private'
         uploader.aws_acl = 'public-read'
         uploader.aws_acl = 'authenticated-read'

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -14,6 +14,8 @@ describe CarrierWave::Uploader::Base do
   end
 
   describe '#aws_acl' do
+    let(:derived_uploader) { FeatureUploader }
+
     it 'allows known acess control values' do
       expect {
         uploader.aws_acl = 'private'
@@ -44,6 +46,14 @@ describe CarrierWave::Uploader::Base do
 
       expect(uploader.aws_acl).to eq('private')
       expect(instance.aws_acl).to eq('public-read')
+    end
+
+    it 'can be looked up from superclass' do
+      uploader.aws_acl = 'private'
+      instance = derived_uploader.new
+
+      expect(derived_uploader.aws_acl).to eq 'private'
+      expect(instance.aws_acl).to eq 'private'
     end
   end
 end

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -63,8 +63,8 @@ describe CarrierWave::Uploader::Base do
       uploader.aws_acl = 'private'
       instance = derived_uploader.new
 
-      expect(derived_uploader.aws_acl).to eq 'private'
-      expect(instance.aws_acl).to eq 'private'
+      expect(derived_uploader.aws_acl).to eq('private')
+      expect(instance.aws_acl).to eq('private')
     end
 
     it 'can be overridden on a class level' do
@@ -72,10 +72,10 @@ describe CarrierWave::Uploader::Base do
       derived_uploader.aws_acl = 'private'
 
       base = uploader.new
-      expect(base.aws_acl).to eq 'public-read'
+      expect(base.aws_acl).to eq('public-read')
 
       instance = derived_uploader.new
-      expect(instance.aws_acl).to eq 'private'
+      expect(instance.aws_acl).to eq('private')
     end
 
     it 'can lookup even if none configured' do

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -77,15 +77,5 @@ describe CarrierWave::Uploader::Base do
       instance = derived_uploader.new
       expect(instance.aws_acl).to eq('private')
     end
-
-    it 'can lookup even if none configured' do
-      expect(uploader.instance_variable_defined?('@aws_acl')).to be false
-      expect(derived_uploader.instance_variable_defined?('@aws_acl')).to be false
-
-      instance = derived_uploader.new
-
-      expect { instance.aws_acl }.not_to raise_exception
-      expect(instance.aws_acl).to be_nil
-    end
   end
 end

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -16,6 +16,17 @@ describe CarrierWave::Uploader::Base do
   describe '#aws_acl' do
     let(:derived_uploader) { FeatureUploader }
 
+    before do
+      # Reset uploader classes
+      if uploader.instance_variable_defined?('@aws_acl')
+        uploader.remove_instance_variable('@aws_acl')
+      end
+
+      if derived_uploader.instance_variable_defined?('@aws_acl')
+        derived_uploader.remove_instance_variable('@aws_acl')
+      end
+    end
+
     it 'allows known acess control values' do
       expect {
         uploader.aws_acl = 'private'
@@ -54,6 +65,27 @@ describe CarrierWave::Uploader::Base do
 
       expect(derived_uploader.aws_acl).to eq 'private'
       expect(instance.aws_acl).to eq 'private'
+    end
+
+    it 'can be overridden on a class level' do
+      uploader.aws_acl = 'public-read'
+      derived_uploader.aws_acl = 'private'
+
+      base = uploader.new
+      expect(base.aws_acl).to eq 'public-read'
+
+      instance = derived_uploader.new
+      expect(instance.aws_acl).to eq 'private'
+    end
+
+    it 'can lookup even if none configured' do
+      expect(uploader.instance_variable_defined?('@aws_acl')).to be false
+      expect(derived_uploader.instance_variable_defined?('@aws_acl')).to be false
+
+      instance = derived_uploader.new
+
+      expect { instance.aws_acl }.not_to raise_exception
+      expect(instance.aws_acl).to be_nil
     end
   end
 end

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -5,6 +5,10 @@ describe CarrierWave::Uploader::Base do
     Class.new(CarrierWave::Uploader::Base)
   end
 
+  let(:derived_uploader) do
+    Class.new(uploader)
+  end
+
   it 'inserts aws as a known storage engine' do
     uploader.configure do |config|
       expect(config.storage_engines).to have_key(:aws)
@@ -16,21 +20,7 @@ describe CarrierWave::Uploader::Base do
   end
 
   describe '#aws_acl' do
-    let(:derived_uploader) { FeatureUploader }
-
-    before do
-      # Reset uploader classes
-      if uploader.instance_variable_defined?('@aws_acl')
-        uploader.remove_instance_variable('@aws_acl')
-      end
-
-      if derived_uploader.instance_variable_defined?('@aws_acl')
-        derived_uploader.remove_instance_variable('@aws_acl')
-      end
-    end
-
-    it 'allows known acess control values' do
-      expect {
+    it 'allows known acess control values' do expect {
         uploader.aws_acl = 'private'
         uploader.aws_acl = 'public-read'
         uploader.aws_acl = 'authenticated-read'


### PR DESCRIPTION
Hi,

I've added a test and a fix for the aws_acl lookup issue we talked about in my other pull request. 

Carrierwaves `add_config` does a lot of magic when generating configuration accessors looking up settings starting on an uploader instance with fallback to its class doing a fallback to its superclass. The new `aws_acl` reader is not doing this but I thing it should:

In a rails project for instance I would configure Carrierwave by calling `CarrierWave.configure ...` in an initializer. The configured `aws_acl` is not visible within the `ImageUploader` nor in instances of `ImageUploader` atm. Using the reader methods defined by calling `add_config :aws_acl` but redefining the setter methods will do the trick.

What do you think?