### PR TITLE
Fix syntax error in documentation for config.aws_signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ CarrierWave.configure do |config|
 
   # Optional: Signing of download urls, e.g. for serving private
   # content through CloudFront.
-  config.aws_signer = -> { |unsigned_url, options| Aws::CF::Signer.sign_url unsigned_url, options }
+  config.aws_signer = -> (unsigned_url, options) { Aws::CF::Signer.sign_url unsigned_url, options }
 end
 ```
 


### PR DESCRIPTION
Hey!

Feels like  you have invalid syntax for lambda in you documentation.Tried and get `SyntaxError` locally