### PR TITLE
Ensure that copied files use the same ACL settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Fix `copy_to` method of `AWS::File` to use the same `aws_acl` configuration
+  used on original uploads so ACL on copied files matches original files.
+
 ## Version 1.0.0 2015-09-18
 
 * Added: ACL options are verified when they are set, and coerced into usable

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -43,7 +43,10 @@ module CarrierWave
       end
 
       def copy_to(new_path)
-        bucket.object(new_path).copy_from(copy_source: "#{bucket.name}/#{file.key}")
+        bucket.object(new_path).copy_from(
+          copy_source: "#{bucket.name}/#{file.key}",
+          acl: uploader.aws_acl
+        )
       end
 
       def signed_url(options = {})

--- a/spec/features/copying_files_spec.rb
+++ b/spec/features/copying_files_spec.rb
@@ -19,7 +19,11 @@ describe 'Copying Files', type: :feature do
     copy_attributes = copy.file.attributes
     copy_attributes.reject! { |k,v| k == :last_modified }
 
+    copy_acl_grants = copy.file.file.acl.grants
+    original_acl_grants = original.file.file.acl.grants
+
     expect(copy_attributes).to eq(original_attributes)
+    expect(copy_acl_grants).to eq(original_acl_grants)
 
     image.close
     original.file.delete


### PR DESCRIPTION
Until now we didn't ensure that the files generated with
`CarrierWave::Storage::AWSFile#copy_to` were given the same ACL
(Access Control List) as the original files.

As explained in https://github.com/sorentwo/carrierwave-aws/issues/81#issue-154100161
the behavior of #copy_to in CarrierWave is use the `fog_public` configuration
option and make files `public-read` (world-accessible) if it is true.

carrierwave-aws uses a different configuration option (`aws_acl`) which
explicitely defines the default ACL for all uploaded files (i.e. `public-read`)
so it makes sense to compare the copied file with the originally uploaded one.

An alternative test method would be to always check that copied files include
an ACL that matches the `aws_acl` but I cannot for the life of me figure out a
way to get aws-sdk-ruby to output the shorthand `acl` (i.e. `public-read` and
not a list of grants) so for now I'm simply checking that the ACL grants for the
copy are equal to those of the original.