### PR TITLE
multipart support for files > 5gb

### DIFF
--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -41,7 +41,11 @@ module CarrierWave
       end
 
       def store(new_file)
-        file.put(aws_options.write_options(new_file))
+        if uploader.path
+          file.upload_file(uploader.path, aws_options.write_options(new_file))
+        else
+          file.put(aws_options.write_options(new_file))
+        end
       end
 
       def copy_to(new_path)

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -41,10 +41,11 @@ module CarrierWave
       end
 
       def store(new_file)
+        options = aws_options.write_options(new_file)
         if uploader.path
-          file.upload_file(uploader.path, aws_options.write_options(new_file))
+          file.upload_file(uploader.path, options)
         else
-          file.put(aws_options.write_options(new_file))
+          file.put(options)
         end
       end
 


### PR DESCRIPTION
When storing an _aws_file_, using **upload_file** rather than **put** exposes multipart support and enables uploading files larger than 5gb. **upload_file** requires _uploader.path_, although will fall back to **put** if missing.