### PR TITLE
Accept carrierwave 1.0.0.beta as dependency

### DIFF
--- a/carrierwave-aws.gemspec
+++ b/carrierwave-aws.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'carrierwave', '~> 0.7'
+  gem.add_dependency 'carrierwave', '>= 0.7', '< 2.0'
   gem.add_dependency 'aws-sdk',     '~> 2.0'
 
   gem.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
I ran the specs with carrierwave 1.0.0.beta and it's all green.