### PR TITLE
Use aws-sdk-s3 gem instead of aws-sdk(v2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rubocop', require: false
 gem 'coveralls', require: false
+gem 'rubocop', require: false

--- a/carrierwave-aws.gemspec
+++ b/carrierwave-aws.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'carrierwave', '>= 0.7', '< 2.0'
-  gem.add_dependency 'aws-sdk-s3', '~> 1.0.0-rc2'
+  gem.add_dependency 'aws-sdk-s3', '~> 1.0.0-rc3'
 
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rspec', '~> 3.0'

--- a/carrierwave-aws.gemspec
+++ b/carrierwave-aws.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'carrierwave', '>= 0.7', '< 2.0'
-  gem.add_dependency 'aws-sdk',     '~> 2.0'
+  gem.add_dependency 'aws-sdk-s3', '~> 1.0.0-rc2'
 
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'aws-sdk-resources'
-
-Aws.eager_autoload!(services: ['S3'])
+require 'aws-sdk-s3'
 
 module CarrierWave
   module Storage

--- a/spec/carrierwave-aws_spec.rb
+++ b/spec/carrierwave-aws_spec.rb
@@ -81,15 +81,15 @@ describe CarrierWave::Uploader::Base do
   end
 
   describe '#aws_signer' do
-    let(:signer_proc) { -> (_unsigned, _options) {} }
-    let(:other_signer) { -> (_unsigned, _options) {} }
+    let(:signer_proc) { ->(_unsigned, _options) {} }
+    let(:other_signer) { ->(_unsigned, _options) {} }
 
     it 'allows proper signer object' do
       expect { uploader.aws_signer = signer_proc }.not_to raise_exception
     end
 
     it 'does not allow signer with unknown api' do
-      signer_proc = -> (_unsigned) {}
+      signer_proc = ->(_unsigned) {}
 
       expect { uploader.aws_signer = signer_proc }
         .to raise_exception(CarrierWave::Uploader::Base::ConfigurationError)


### PR DESCRIPTION
 Use aws-sdk-s3 gem(~> v1.0.0) instead of aws-sdk(v2) to make dependency gems less. 

Changes
----

- require 'aws-sdk-s3' becuase 'aws-sdk-resources' is deprecated
- Fix Rubocop errors

Reference
----

- [Upgrading from Version 2 to Version 3 of the AWS SDK for Ruby | AWS Developer Blog](https://aws.amazon.com/jp/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/)