### PR TITLE
Add block support to AWSFile read method

### DIFF
--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -37,7 +37,12 @@ module CarrierWave
       end
 
       def read
-        file.get(aws_options.read_options).body.read
+        if block_given?
+          file.get(aws_options.read_options) { |chunk| yield chunk }
+          nil
+        else
+          file.get(aws_options.read_options).body.read
+        end
       end
 
       def store(new_file)

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -37,11 +37,12 @@ module CarrierWave
       end
 
       def read
+        read_options = aws_options.read_options
         if block_given?
-          file.get(aws_options.read_options) { |chunk| yield chunk }
+          file.get(read_options) { |chunk| yield chunk }
           nil
         else
-          file.get(aws_options.read_options).body.read
+          file.get(read_options).body.read
         end
       end
 

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -44,6 +44,22 @@ describe CarrierWave::Storage::AWSFile do
     end
   end
 
+  describe '#read' do
+    let(:s3_object) { double('Aws::S3::Object') }
+    before          { aws_file.file = s3_object }
+
+    it 'reads the retrieved body if called without block' do
+      expect(s3_object).to receive_message_chain('get.body.read')
+      aws_file.read
+    end
+
+    it 'does not retrieve body if block given' do
+      proc = Proc.new { }
+      expect(s3_object).to receive('get')
+      expect(aws_file.read(&proc)).to be_nil
+    end
+  end
+
   describe '#url' do
     it 'requests a public url if acl is public readable' do
       allow(uploader).to receive(:aws_acl) { :'public-read' }

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -56,7 +56,7 @@ describe CarrierWave::Storage::AWSFile do
 
     it 'does not retrieve body if block given' do
       aws_file.file = s3_object
-      block = Proc.new {}
+      block = proc {}
 
       expect(s3_object).to receive('get')
       expect(aws_file.read(&block)).to be_nil

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -45,18 +45,21 @@ describe CarrierWave::Storage::AWSFile do
   end
 
   describe '#read' do
-    let(:s3_object) { double('Aws::S3::Object') }
-    before          { aws_file.file = s3_object }
+    let(:s3_object) { instance_double('Aws::S3::Object') }
 
     it 'reads the retrieved body if called without block' do
+      aws_file.file = s3_object
+
       expect(s3_object).to receive_message_chain('get.body.read')
       aws_file.read
     end
 
     it 'does not retrieve body if block given' do
-      proc = Proc.new { }
+      aws_file.file = s3_object
+      block = Proc.new {}
+
       expect(s3_object).to receive('get')
-      expect(aws_file.read(&proc)).to be_nil
+      expect(aws_file.read(&block)).to be_nil
     end
   end
 


### PR DESCRIPTION
Hi @sorentwo!

Thanks again for this awesome library. 👍

Past weekend I've played around with creating (and afterwards uploading) zip-files of big AWSFile's on a Heroku free tier project. The naive implementation was using AWSFile's `read` method to retrieve the data and passed it to ruby zip. My worker was killed because of it's memory usage almost immediately.  

The current implementation of the `read` method in `CarrierWave::Storage::AWSFile` dumps the S3 object data into memory. [Aws::S3::Object#get](http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html#get-instance_method) and [Aws::S3::Client#get_object](http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html#get_object-instance_method) allows to pass a block to read the data in chunks. I've added support of this to `AWSFile#read`. Now it's possible to do 
```
Zip::OutputStream.open(tempfile.path) do |z|
  photos.each do |photo|
    z.put_next_entry photo.name
    photo.image.read { |chunk| z.write chunk }
  end
end
# ...tempfile upload code
```
What do you think about?

In addition, it could be useful to have the ability to pass read options to the `read` method directly in order to forward e.g the `response_target` option to the aws-sdk in order to download files directly without consuming too much memory?

I know that this method signature differs from the in [CarrierWave:: Uploader:: Proxy](carrierwave/lib/carrierwave/uploader/proxy.rb) implementation, but maybe we could ask to change it as soon as we know how we would like to have it. 😉 For the meantime it's possible to add something like
```
def read(&block)
  file.read(&block) if file.respond_to? :read
end
```
to the uploader.