### PR TITLE
Cache store

### DIFF
--- a/lib/carrierwave/storage/aws.rb
+++ b/lib/carrierwave/storage/aws.rb
@@ -25,6 +25,24 @@ module CarrierWave
         AWSFile.new(uploader, connection, uploader.store_path(identifier))
       end
 
+      def cache!(file)
+        AWSFile.new(uploader, connection, uploader.cache_path).tap do |aws_file|
+          aws_file.store(file)
+        end
+      end
+
+      def retrieve_from_cache!(identifier)
+        AWSFile.new(uploader, connection, uploader.cache_path(identifier))
+      end
+
+      def delete_dir!(path)
+        # NOTE: noop, because there are no directories on S3
+      end
+
+      def clean_cache!(_seconds)
+        raise 'use Object Lifecycle Management to clean the cache'
+      end
+
       def connection
         @connection ||= begin
           conn_cache = self.class.connection_cache

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -47,12 +47,23 @@ module CarrierWave
       end
 
       def store(new_file)
-        file.put(aws_options.write_options(new_file))
+        if new_file.is_a?(self.class)
+          new_file.move_to(path)
+        else
+          file.put(aws_options.write_options(new_file))
+        end
       end
 
       def copy_to(new_path)
         bucket.object(new_path).copy_from(
           copy_source: "#{bucket.name}/#{file.key}",
+          acl: uploader.aws_acl
+        )
+      end
+
+      def move_to(new_path)
+        file.move_to(
+          "#{bucket.name}/#{new_path}",
           acl: uploader.aws_acl
         )
       end

--- a/spec/features/deleting_files_spec.rb
+++ b/spec/features/deleting_files_spec.rb
@@ -9,6 +9,5 @@ describe 'Deleting Files', type: :feature do
     instance.store!(image)
   end
 
-  it 'deletes the image when assigned a `nil` value' do
-  end
+  it 'deletes the image when assigned a `nil` value'
 end

--- a/spec/features/moving_files_spec.rb
+++ b/spec/features/moving_files_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'Moving Files', type: :feature do
+  let(:image)    { File.open('spec/fixtures/image.png', 'r') }
+  let(:original) { FeatureUploader.new }
+
+  it 'copies an existing file to the specified path' do
+    original.store!(image)
+    original.retrieve_from_store!('image.png')
+
+    original_attributes = original.file.attributes
+    original_acl_grants = original.file.file.acl.grants
+
+    original.file.move_to('uploads/image2.png')
+
+    move = FeatureUploader.new
+    move.retrieve_from_store!('image2.png')
+
+    copy_attributes = move.file.attributes
+    copy_acl_grants = move.file.file.acl.grants
+
+    expect(copy_attributes).to eq(original_attributes)
+    expect(copy_acl_grants).to eq(original_acl_grants)
+    expect(original.file).not_to exist
+
+    image.close
+    move.file.delete
+  end
+end

--- a/spec/features/storing_files_spec.rb
+++ b/spec/features/storing_files_spec.rb
@@ -63,4 +63,32 @@ describe 'Storing Files', type: :feature do
     image.close
     instance.file.delete
   end
+
+  it 'uploads the cache file to the configured bucket' do
+    instance.cache!(image)
+    instance.retrieve_from_cache!(instance.cache_name)
+
+    expect(instance.file.size).to be_nonzero
+    expect(image.size).to eq(instance.file.size)
+
+    image.close
+    instance.file.delete
+  end
+
+  it 'moves cached files to final location when storing' do
+    instance.cache!(image)
+    cache_name = instance.cache_name
+    instance.store!
+
+    instance.retrieve_from_cache!(cache_name)
+    expect(instance.file).not_to exist
+
+    instance.retrieve_from_store!('image.png')
+    expect(instance.file.size).to eq(image.size)
+    expect(instance.file.read).to eq(image.read)
+    expect(instance.file.read).to eq(instance.file.read)
+
+    image.close
+    instance.file.delete
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,9 +36,10 @@ RSpec.configure do |config|
 
   config.before(:all, type: :feature) do
     CarrierWave.configure do |cw_config|
-      cw_config.storage    = :aws
-      cw_config.aws_bucket = ENV['S3_BUCKET_NAME']
-      cw_config.aws_acl    = :'public-read'
+      cw_config.storage       = :aws
+      cw_config.cache_storage = :aws
+      cw_config.aws_bucket    = ENV['S3_BUCKET_NAME']
+      cw_config.aws_acl       = :'public-read'
 
       cw_config.aws_credentials = {
         access_key_id:     ENV['S3_ACCESS_KEY'],


### PR DESCRIPTION
*updates #18*

I didn't implement the `clean_cache!`-method, as this should be done using Object Lifecycle Management in my opinion. I'm not sure about the `delete_dir!`-method, it was like this in the previous PR.

One unrelated change: there was an unimplemented spec (which left files lying around the s3 bucket after the specs ran) which I marked as pending.

This is a really cool change by the way, as it is now really easy to do direct file uploads to s3, like `refile` does them (uploading to a cache directory, then moving files to final storage location).