### PR TITLE
update aws to ~> 2.1 because Aws.eager_autoload! was introduced in 2.1.0

### DIFF
--- a/carrierwave-aws.gemspec
+++ b/carrierwave-aws.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'carrierwave', '>= 0.7', '< 2.0'
-  gem.add_dependency 'aws-sdk',     '~> 2.0'
+  gem.add_dependency 'aws-sdk',     '~> 2.1'
 
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
see issue #112 