### PR TITLE
Support large files, reduce memory usage

### DIFF
--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -56,7 +56,7 @@ module CarrierWave
         if new_file.is_a?(self.class)
           new_file.move_to(path)
         else
-          file.put(aws_options.write_options(new_file))
+          file.upload_file(new_file.path, aws_options.write_options(new_file))
         end
       end
 

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -101,4 +101,29 @@ describe CarrierWave::Storage::AWSFile do
       expect(aws_file.url).to eq('http://example.com/files/1/file.txt')
     end
   end
+
+  describe '#store' do
+    context 'when new_file is an AWSFile' do
+      let(:new_file) do
+        CarrierWave::Storage::AWSFile.new(uploader, connection, path)
+      end
+
+      it 'moves the object' do
+        expect(new_file).to receive(:move_to).with(path)
+        aws_file.store(new_file)
+      end
+    end
+
+    context 'when new file if a SanitizedFile' do
+      let(:new_file) do
+        CarrierWave::SanitizedFile.new('spec/fixtures/image.png')
+      end
+
+      it 'uploads the file using with multipart support' do
+        expect(file).to(receive(:upload_file)
+                              .with(new_file.path, an_instance_of(Hash)))
+        aws_file.store(new_file)
+      end
+    end
+  end
 end

--- a/spec/features/storing_files_spec.rb
+++ b/spec/features/storing_files_spec.rb
@@ -20,6 +20,26 @@ describe 'Storing Files', type: :feature do
     instance.file.delete
   end
 
+  it 'uploads a StringIO to the configured bucket' do
+    # https://github.com/carrierwaveuploader/carrierwave/wiki/How-to:-Upload-from-a-string-in-Rails-3-or-later
+    io = StringIO.new(image.read)
+
+    def io.original_filename
+      'image.png'
+    end
+    image.rewind
+
+    instance.store!(io)
+    instance.retrieve_from_store!('image.png')
+
+    expect(instance.file.size).to eq(image.size)
+    expect(instance.file.read).to eq(image.read)
+    expect(instance.file.read).to eq(instance.file.read)
+
+    image.close
+    instance.file.delete
+  end
+
   it 'retrieves the attributes for a stored file' do
     instance.store!(image)
     instance.retrieve_from_store!('image.png')


### PR DESCRIPTION
This PR adds support for uploading large files, by using the underlying `#upload_file` instead of `#put`.

It has been previously discussed by others in #83 and #84.

As noted in the [AWS Developer Blog](https://aws.amazon.com/blogs/developer/uploading-files-to-amazon-s3/), this has the following benefits:

- Manages multipart uploads for objects larger than 15MB.
- Correctly opens files in binary mode to avoid encoding issues.
- Uses multiple threads for uploading parts of large objects in parallel.

> I recommend you use #upload_file whenever possible.

In addition, this reduces the memory used by the uploading process. For example, using `#put` with a file that is more than the memory available for the process results in an out-of-memory error. Using `#upload_file` works just fine.

As far as I can tell, the `new_file` being passed in to `AwsFile#store` always has a path available, because it has gone through `CarrierWave::Uploader::Cache#cache!` and it has already been either moved or copied there. Relevant source for [Cache](https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/uploader/cache.rb#L118) and [SanitizedFile](https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/sanitized_file.rb#L181).

I added an new integration spec that illustrates that even starting from a StringIO, using `#upload_file` is successful.

Maintainers: Thank you for your open source contributions!. I tried to follow the guidelines, existing style and function of the library. Please do let me know if have concerns with the code as it is written.

