### PR TITLE
Setting license in gem package spec.

### DIFF
--- a/carrierwave-aws.gemspec
+++ b/carrierwave-aws.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/sorentwo/carrierwave-aws'
   gem.description = 'Use aws-sdk for S3 support in CarrierWave'
   gem.summary = 'Native aws-sdk support for S3 in CarrierWave'
+  gem.license = 'MIT'
 
   gem.files = `git ls-files -z lib spec`.split("\x0")
   gem.test_files = gem.files.grep(%r{^(spec)/})


### PR DESCRIPTION
To allow automated tools (such as
LicenseFinder [https://github.com/pivotal/LicenseFinder]) to detect and
report licenses in use by a system and its dependencies.

Further details here: https://github.com/pivotal/LicenseFinder#a-plea-to-package-authors-and-maintainers