### PR TITLE
Apply configured aws_options when moving / copying files

### DIFF
--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -63,12 +63,15 @@ module CarrierWave
       def copy_to(new_path)
         bucket.object(new_path).copy_from(
           "#{bucket.name}/#{file.key}",
-          aws_options.copy_options
+          aws_options.copy_options(self)
         )
       end
 
       def move_to(new_path)
-        file.move_to("#{bucket.name}/#{new_path}", aws_options.move_options)
+        file.move_to(
+          "#{bucket.name}/#{new_path}",
+          aws_options.move_options(self)
+        )
       end
 
       def signed_url(options = {})

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -62,16 +62,13 @@ module CarrierWave
 
       def copy_to(new_path)
         bucket.object(new_path).copy_from(
-          copy_source: "#{bucket.name}/#{file.key}",
-          acl: uploader.aws_acl
+          "#{bucket.name}/#{file.key}",
+          aws_options.copy_options
         )
       end
 
       def move_to(new_path)
-        file.move_to(
-          "#{bucket.name}/#{new_path}",
-          acl: uploader.aws_acl
-        )
+        file.move_to("#{bucket.name}/#{new_path}", aws_options.move_options)
       end
 
       def signed_url(options = {})

--- a/lib/carrierwave/storage/aws_options.rb
+++ b/lib/carrierwave/storage/aws_options.rb
@@ -3,6 +3,8 @@
 module CarrierWave
   module Storage
     class AWSOptions
+      MULTIPART_TRESHOLD = 15 * 1024 * 1024
+
       attr_reader :uploader
 
       def initialize(uploader)
@@ -21,9 +23,10 @@ module CarrierWave
         }.merge(aws_attributes).merge(aws_write_options)
       end
 
-      def move_options
+      def move_options(file)
         {
-          acl: uploader.aws_acl
+          acl: uploader.aws_acl,
+          multipart_copy: file.size >= MULTIPART_TRESHOLD
         }.merge(aws_attributes).merge(aws_write_options)
       end
       alias copy_options move_options

--- a/lib/carrierwave/storage/aws_options.rb
+++ b/lib/carrierwave/storage/aws_options.rb
@@ -21,6 +21,13 @@ module CarrierWave
         }.merge(aws_attributes).merge(aws_write_options)
       end
 
+      def move_options
+        {
+          acl: uploader.aws_acl
+        }.merge(aws_attributes).merge(aws_write_options)
+      end
+      alias copy_options move_options
+
       def expiration_options(options = {})
         uploader_expiration = uploader.aws_authenticated_url_expiration
 


### PR DESCRIPTION
This PR does 2 things:
1. Apply aws_options when moving / copying files. In my case this was necessary because I have server_side_encryption enabled, and when the file was moved from cache to store, an error occurred (because writing unencrypted files is forbidden in the bucket policy).
2. Use multipart_copy when moving / copying large files. This speeds up these operations for large files, and is essentially the same `upload_file` does.