### PR TITLE
URL encode path when constructing `public_url`

### DIFF
--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -84,7 +84,7 @@ module CarrierWave
 
       def public_url
         if uploader.asset_host
-          "#{uploader.asset_host}/#{path}"
+          "#{uploader.asset_host}/#{uri_path}"
         else
           file.public_url.to_s
         end
@@ -108,6 +108,10 @@ module CarrierWave
 
       def signer
         uploader.aws_signer
+      end
+
+      def uri_path
+        path.gsub(%r{[^/]+}) { |segment| Seahorse::Util.uri_escape(segment) }
       end
     end
   end

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -126,4 +126,12 @@ describe CarrierWave::Storage::AWSFile do
       end
     end
   end
+
+  describe '#public_url' do
+    it 'uri-encodes the path' do
+      allow(uploader).to receive(:asset_host) { 'http://example.com' }
+      aws_file.path = 'uploads/images/jekyll+and+hyde.txt'
+      expect(aws_file.public_url).to eq 'http://example.com/uploads/images/jekyll%2Band%2Bhyde.txt'
+    end
+  end
 end


### PR DESCRIPTION
When `asset_host` is set we construct the `public_url` by concatenating `asset_host` and `path`. However, since the `path` is not URL encoded, fetching the image through the `public_url` may fail when it includes characters like "+" in the filename