### PR TITLE
Document config option for using AWS stub_responses during test

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ CarrierWave.configure do |config|
   config.aws_credentials = {
     access_key_id:     ENV.fetch('AWS_ACCESS_KEY_ID'),
     secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
-    region:            ENV.fetch('AWS_REGION') # Required
+    region:            ENV.fetch('AWS_REGION'), # Required
+    stub_responses:    Rails.env.test? # Optional, avoid hitting S3 actual during tests
   }
 
   # Optional: Signing of download urls, e.g. for serving private content through


### PR DESCRIPTION
Based on https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/stubbing.html

It took me a bit of digging through the code to figure out this would work, but it cuts about 2.5 minutes off our test suite so figured someone else might find it useful to know.