### PR TITLE
Add support for serving from private bucket with public cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ CarrierWave.configure do |config|
   # Optionally define an asset host for configurations that are fronted by a
   # content host, such as CloudFront.
   config.asset_host = 'http://example.com'
+  config.asset_public_host = true
 
   # The maximum period for authenticated_urls is only 7 days.
   config.aws_authenticated_url_expiration = 60 * 60 * 24 * 7

--- a/lib/carrierwave-aws.rb
+++ b/lib/carrierwave-aws.rb
@@ -29,6 +29,7 @@ module CarrierWave
       add_config :aws_write_options
       add_config :aws_acl
       add_config :aws_signer
+      add_config :asset_host_public
 
       configure do |config|
         config.storage_engines[:aws] = 'CarrierWave::Storage::AWS'
@@ -82,6 +83,10 @@ module CarrierWave
         else
           self.class.aws_signer
         end
+      end
+
+      def asset_public_host
+        @asset_public_host || false
       end
     end
   end

--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -93,10 +93,10 @@ module CarrierWave
       def url(options = {})
         if signer
           signed_url(options)
-        elsif uploader.aws_acl.to_s != 'public-read'
-          authenticated_url(options)
-        else
+        elsif public?
           public_url
+        else
+          authenticated_url(options)
         end
       end
 
@@ -112,6 +112,10 @@ module CarrierWave
 
       def uri_path
         path.gsub(%r{[^/]+}) { |segment| Seahorse::Util.uri_escape(segment) }
+      end
+
+      def public?
+        uploader.aws_acl.to_s == 'public-read' || uploader.asset_host_public
       end
     end
   end

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -72,9 +72,19 @@ describe CarrierWave::Storage::AWSFile do
       aws_file.url
     end
 
+    it 'requests a public url if asset_host_public' do
+      allow(uploader).to receive(:aws_acl) { :'authenticated-read' }
+      allow(uploader).to receive(:asset_host_public) { true }
+
+      expect(file).to receive(:public_url)
+
+      aws_file.url
+    end
+
     it 'requests an authenticated url if acl is not public readable' do
       allow(uploader).to receive(:aws_acl) { :private }
       allow(uploader).to receive(:aws_authenticated_url_expiration) { 60 }
+      allow(uploader).to receive(:asset_host_public) { false }
 
       expect(file).to receive(:presigned_url).with(:get, expires_in: 60)
 


### PR DESCRIPTION
This PR addresses the use-case of serving a private bucket through unsigned cloudfront urls. AWS allows this by creating a policy for a cloudfront origin identity associated to the cloudfront distribution to the s3 bucket.