### PR TITLE
Update carrierwave to < 2.1

### DIFF
--- a/carrierwave-aws.gemspec
+++ b/carrierwave-aws.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'carrierwave', '>= 0.7', '< 2.0'
+  gem.add_dependency 'carrierwave', '>= 0.7', '< 2.1'
   gem.add_dependency 'aws-sdk-s3', '~> 1.0'
 
   gem.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Hi! First of all, thanks for your making this gem! I use this gem in my project!

Yesterday, CarrierWave 2.0.0 was released, so I update the dependency version.