### PR TITLE
README: fix custom AWS endpoint example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ end
 If you are using a non-standard endpoint for S3 service (eg: Swiss-based Exoscale S3) you can override it like this
 
 ```ruby
-    config.aws_credentials.config = AWS.config({
-        s3_endpoint: 'my.custom.s3.service.com'
-    })
+    config.aws_credentials[:endpoint] = 'my.custom.s3.service.com'
 ```
 
 ### Custom options for AWS URLs


### PR DESCRIPTION
Starting from sdk >= 2.x the former example does not work.