### PR TITLE
warning: URI.unescape is obsolete

### DIFF
--- a/lib/carrierwave/support/uri_filename.rb
+++ b/lib/carrierwave/support/uri_filename.rb
@@ -6,7 +6,7 @@ module CarrierWave
       def self.filename(url)
         path = url.split('?').first
 
-        URI.decode(path).gsub(%r{.*/(.*?$)}, '\1')
+        CGI.unescape(path).gsub(%r{.*/(.*?$)}, '\1')
       end
     end
   end


### PR DESCRIPTION
Hello.

When running with Ruby 2.7.0, some warnings about URI.unescape are output.

```
$ bundle exec rspec
Run options:
  include {:focus=>true}
  exclude {:type=>:feature}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 19295
...................................../home/jit-y/dev/.ghq/github.com/sorentwo/carrierwave-aws/lib/carrierwave/support/uri_filename.rb:9: warning: URI.unescape is obsolete
/home/jit-y/dev/.ghq/github.com/sorentwo/carrierwave-aws/lib/carrierwave/support/uri_filename.rb:9: warning: URI.unescape is obsolete
...

Finished in 0.02729 seconds (files took 0.40844 seconds to load)
40 examples, 0 failures

Randomized with seed 19295
```

This is because URI.decode warning is output even if not in verbose mode from ruby ​​2.7.0.

https://github.com/ruby/ruby/pull/2494/commits/c232a8232963c105ae22577d815182f074d7d1d3

In this PR URI.decode is replaced with CGI.unescape to remove these warnings.

Thanks.
