### PR TITLE
Update implementation of AWSFile#copy_to to use S3Object#copy_to API

### DIFF
--- a/lib/carrierwave/storage/aws_file.rb
+++ b/lib/carrierwave/storage/aws_file.rb
@@ -61,8 +61,8 @@ module CarrierWave
       end
 
       def copy_to(new_path)
-        bucket.object(new_path).copy_from(
-          "#{bucket.name}/#{file.key}",
+        file.copy_to(
+          bucket.object(new_path),
           aws_options.copy_options(self)
         )
       end

--- a/spec/carrierwave/storage/aws_file_spec.rb
+++ b/spec/carrierwave/storage/aws_file_spec.rb
@@ -144,4 +144,21 @@ describe CarrierWave::Storage::AWSFile do
       expect(aws_file.public_url).to eq 'http://example.com/uploads/images/jekyll%2Band%2Bhyde.txt'
     end
   end
+
+  describe '#copy_to' do
+    let(:new_s3_object) { instance_double('Aws::S3::Object') }
+
+    it 'copies file to target path' do
+      new_path = 'files/2/file.txt'
+      expect(bucket).to receive(:object).with(new_path).and_return(new_s3_object)
+      expect(file).to receive(:size).at_least(:once).and_return(1024)
+      expect(file).to(
+        receive(:copy_to).with(
+          new_s3_object,
+          aws_file.aws_options.copy_options(aws_file)
+        )
+      )
+      aws_file.copy_to new_path
+    end
+  end
 end


### PR DESCRIPTION
### Reason
- Better support for special characters
  - According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html, there are some characters, such as `+ (Plus)`, that are not necessary to be sanitized but requires special treatment. 
  - We have encountered issues with filename containing `+` fails to copy correctly. `S3Object#copy_to` appears to handle this already if the target is a `S3Object`. 
- Utilizing the underlying `S3Object`'s API with the same name seems to make more sense

Hope this makes sense and let me know what you think!