### PR TITLE
Fix typo in constant name: MULTIPART_TRESHOLD → MULTIPART_THRESHOLD (keep backward compatibility)

### DIFF
--- a/lib/carrierwave/storage/aws_options.rb
+++ b/lib/carrierwave/storage/aws_options.rb
@@ -3,7 +3,10 @@
 module CarrierWave
   module Storage
     class AWSOptions
-      MULTIPART_TRESHOLD = 15 * 1024 * 1024
+      MULTIPART_THRESHOLD = 15 * 1024 * 1024
+
+      # Backward compatibility
+      MULTIPART_TRESHOLD = MULTIPART_THRESHOLD
 
       attr_reader :uploader
 
@@ -26,7 +29,7 @@ module CarrierWave
       def move_options(file)
         {
           acl: uploader.aws_acl,
-          multipart_copy: file.size >= MULTIPART_TRESHOLD
+          multipart_copy: file.size >= MULTIPART_THRESHOLD
         }.merge(aws_attributes).merge(aws_write_options)
       end
       alias copy_options move_options


### PR DESCRIPTION
# Overview
- This pull request fixes a typo in the constant name `MULTIPART_TRESHOLD` defined in `lib/carrierwave/storage/aws_options.rb`.
- The correct spelling should be `MULTIPART_THRESHOLD`.

# Changes
- Add a new constant `MULTIPART_THRESHOLD` with the same value.
- Keep the existing `MULTIPART_TRESHOLD` definition for backward compatibility.

# Notes
- No behavior changes are introduced.
- Users referencing the old constant will not be affected.
- The old constant can be deprecated in a future major release if needed.

